### PR TITLE
Update size of images

### DIFF
--- a/components/image/image-component.js
+++ b/components/image/image-component.js
@@ -19,16 +19,25 @@ class ImageComponent extends HTMLElement {
   render() {
     const div = document.createElement("div");
     div.innerHTML = `
-    <img id="${this.tag}" src="${this.source}" alt="${this.subtitle}">
-    <sub>${this.subtitle}</sub>
+    <div class="container">
+      <img id="${this.tag}" src="${this.source}" alt="${this.subtitle}">
+      <sub>${this.subtitle}</sub>
+    </div>
     <style>
       :host {
         display: block;
         text-align: center;
       }
 
+      .container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+
       img {
-        width: 100%;
+        width: 50%;
       }
 
       sub {
@@ -38,6 +47,7 @@ class ImageComponent extends HTMLElement {
     </style>
   `;
 
+    this.shadowRoot.innerHTML = ""; // Clear previous content
     this.shadowRoot.appendChild(div);
   }
 }

--- a/components/image/image-full.js
+++ b/components/image/image-full.js
@@ -1,0 +1,56 @@
+class ImageFull extends HTMLElement {
+    static get observedAttributes() {
+        return ["tag", "source", "subtitle"];
+    }
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: "open" });
+    }
+
+    connectedCallback() {
+        this.render();
+    }
+
+    attributeChangedCallback(name, _, newValue) {
+        this[name] = newValue;
+    }
+
+    render() {
+        const div = document.createElement("div");
+        div.innerHTML = `
+    <div class="container">
+      <img id="${this.tag}" src="${this.source}" alt="${this.subtitle}">
+      <sub>${this.subtitle}</sub>
+    </div>
+    <style>
+      :host {
+        display: block;
+        text-align: center;
+      }
+
+      .container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+
+      img {
+        width: 100%;
+      }
+
+      sub {
+        font-size: 1rem;
+        font-style: italic;
+      }
+    </style>
+  `;
+
+        this.shadowRoot.innerHTML = ""; // Clear previous content
+        this.shadowRoot.appendChild(div);
+    }
+
+}
+
+customElements.define("image-full", ImageFull);

--- a/index.css
+++ b/index.css
@@ -21,3 +21,14 @@ p {
   text-align: justify;
   font-size: 1.1rem;
 }
+
+.sidenav {
+  width: 200px; /* Fixed width for sidenav */
+  background-color: lightgray;
+}
+
+.content {
+  justify-content: center; /* Center horizontally */
+  align-items: center; /* Center vertically */
+  padding-left: 250px; /* Optional: Add spacing from the edge */
+}

--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
   
   <script type="module" src="./components/image/image-component.js"></script>
 
+  <script type="module" src="components/image/image-full.js"></script>
+
   <script type="module" src="./components/video/video.js"></script>
 
   <link rel="stylesheet" href="./components/references/references.css">
@@ -217,8 +219,8 @@
       
       <div id="sub-section-1-header-2">
         <h3>1.2 Scoring System</h3>
-        <image-component tag="image" source="./assets/section-1/figure_1_2_scoringTable.png"
-                         subtitle="Figure 1.2: Scoring System for SAFMC 2025"></image-component>
+        <image-half tag="image" source="./assets/section-1/figure_1_2_scoringTable.png"
+                         subtitle="Figure 1.2: Scoring System for SAFMC 2025"></image-half>
         <p>
           Figure 1.2 shows the scoring system for SAFMC 2025.
         </p>
@@ -231,8 +233,8 @@
           Figure 1.3 shows how the Arena this year will look like, which is not drawn to scale. Furthermore, the Danger Zones, Regular Victims and Bonus Victims may not be placed exactly where it is depicted in Figure 1.3. There is a maximum of two simultaneous take-offs of two runs per team. For each run, the placement of Danger Zones, Regular Victims and Bonus Victims may change. 
         </p>
 
-        <image-component tag="image" source="assets\section-1\figure_1_3_SAFMC_2025_playing_field.png"
-        subtitle="Figure 1.3: SAFMC 2025 Arena"></image-component>
+        <image-half tag="image" source="assets\section-1\figure_1_3_SAFMC_2025_playing_field.png"
+        subtitle="Figure 1.3: SAFMC 2025 Arena"></image-half>
 
         <p>
           Figure 1.4 shows the dimensions of the key elements within the Arena.
@@ -1220,8 +1222,8 @@
             Figure 10.1 below illustrates the project Gantt chart for each subsystem, showing the activities that will take place.
             </p>
 
-            <image-component tag="image" source="assets\section-10\figure_10_1_project_gantt_chart.png"
-            subtitle="Figure 10.1: Project Gantt Chart"></image-component>
+            <image-full tag="image" source="assets\section-10\figure_10_1_project_gantt_chart.png"
+            subtitle="Figure 10.1: Project Gantt Chart"></image-full>
           
       </div>
 


### PR DESCRIPTION
This includes changing the main image-component to take up 50% of the width of the page, down from 100% 
Also created a new file called image-full that takes up the full width, which is useful for large images such as the gantt chart Also changed styling on the main page to centralise the content between the navbar and the right side